### PR TITLE
Add Ellipse by modifying Circle transform.scale

### DIFF
--- a/src/shapes/disc.rs
+++ b/src/shapes/disc.rs
@@ -104,7 +104,7 @@ impl ShapeComponent for Disc {
                 transform.scale.y *= extents.y / radius;
                 (radius, transform)
             }
-            None => (radius, tf.compute_transform()), // compute transform here too for matching types
+            None => (self.radius, tf.compute_transform()), // compute transform here too for matching types
         };
 
         DiscData {
@@ -294,7 +294,7 @@ impl DiscBundle for ShapeBundle<Disc> {
     }
 
     fn ellipse(config: &ShapeConfig, extents: Vec2) -> Self {
-        Self::new(config, Disc::ellipse(self.config(), extents))
+        Self::new(config, Disc::ellipse(config, extents))
     }
 }
 

--- a/src/shapes/disc.rs
+++ b/src/shapes/disc.rs
@@ -133,6 +133,7 @@ impl Default for Disc {
             arc: false,
 
             radius: 1.0,
+            extents: None,
             start_angle: 0.0,
             end_angle: 0.0,
         }

--- a/src/shapes/disc.rs
+++ b/src/shapes/disc.rs
@@ -28,6 +28,8 @@ pub struct Disc {
 
     /// External radius of the disc
     pub radius: f32,
+    /// width and height of the disc, overwrites radius if set
+    pub extents: Option<Vec2>,
     /// Starting angle for an arc
     pub start_angle: f32,
     /// Ending angle for an arc
@@ -38,6 +40,7 @@ impl Disc {
     pub fn new(
         config: &ShapeConfig,
         radius: f32,
+        extents: Option<Vec2>,
         arc: bool,
         start_angle: f32,
         end_angle: f32,
@@ -53,17 +56,30 @@ impl Disc {
             arc,
 
             radius,
+            extents,
             start_angle,
             end_angle,
         }
     }
 
     pub fn circle(config: &ShapeConfig, radius: f32) -> Self {
-        Self::new(config, radius, false, 0.0, 0.0, Cap::None)
+        Self::new(config, radius, None, false, 0.0, 0.0, Cap::None)
     }
 
     pub fn arc(config: &ShapeConfig, radius: f32, start_angle: f32, end_angle: f32) -> Self {
-        Self::new(config, radius, true, start_angle, end_angle, config.cap)
+        Self::new(
+            config,
+            radius,
+            None,
+            true,
+            start_angle,
+            end_angle,
+            config.cap,
+        )
+    }
+
+    pub fn ellipse(config: &ShapeConfig, extents: Vec2) -> Self {
+        Self::new(config, 0.0, Some(extents), false, 0.0, 0.0, Cap::None)
     }
 }
 
@@ -78,14 +94,27 @@ impl ShapeComponent for Disc {
         flags.set_cap(self.cap);
         flags.set_arc(self.arc as u32);
 
+        // adjust transfom if extents are set
+        let (radius, transform) = match self.extents {
+            Some(extents) => {
+                let mut transform = tf.compute_transform(); // annoying, but makes it so much easier
+
+                let radius = (extents.x + extents.y) / 2.0; // base radius, will be distorted by scale to achieve ellipse
+                transform.scale.x *= extents.x / radius;
+                transform.scale.y *= extents.y / radius;
+                (radius, transform)
+            }
+            None => (radius, tf.compute_transform()), // compute transform here too for matching types
+        };
+
         DiscData {
-            transform: tf.compute_matrix().to_cols_array_2d(),
+            transform: transform.compute_matrix().to_cols_array_2d(),
 
             color: self.color.as_linear_rgba_f32(),
             thickness: self.thickness,
             flags: flags.0,
 
-            radius: self.radius,
+            radius: radius,
             start_angle: self.start_angle,
             end_angle: self.end_angle,
         }
@@ -135,6 +164,33 @@ impl DiscData {
 
         DiscData {
             transform: config.transform.compute_matrix().to_cols_array_2d(),
+
+            color: config.color.as_linear_rgba_f32(),
+            thickness: config.thickness,
+            flags: flags.0,
+
+            radius,
+
+            start_angle: 0.0,
+            end_angle: 0.0,
+        }
+    }
+
+    pub fn ellipse(config: &ShapeConfig, extents: Vec2) -> DiscData {
+        let mut flags = Flags(0);
+        flags.set_thickness_type(config.thickness_type);
+        flags.set_alignment(config.alignment);
+        flags.set_hollow(config.hollow as u32);
+        flags.set_arc(false as u32);
+
+        let mut transform = config.transform;
+
+        let radius = (extents.x + extents.y) / 2.0; // base radius, will be distorted by scale to achieve ellipse
+        transform.scale.x *= extents.x / radius;
+        transform.scale.y *= extents.y / radius;
+
+        DiscData {
+            transform: transform.compute_matrix().to_cols_array_2d(),
 
             color: config.color.as_linear_rgba_f32(),
             thickness: config.thickness,
@@ -203,6 +259,7 @@ impl ShapeData for DiscData {
 pub trait DiscPainter {
     fn circle(&mut self, radius: f32) -> &mut Self;
     fn arc(&mut self, radius: f32, start_angle: f32, end_angle: f32) -> &mut Self;
+    fn ellipse(&mut self, extents: Vec2) -> &mut Self;
 }
 
 impl<'w, 's> DiscPainter for ShapePainter<'w, 's> {
@@ -214,12 +271,17 @@ impl<'w, 's> DiscPainter for ShapePainter<'w, 's> {
         self.send(DiscData::arc(self.config(), radius, start_angle, end_angle));
         self
     }
+
+    fn ellipse(&mut self, extents: Vec2) -> &mut Self {
+        self.send(DiscData::ellipse(self.config(), extents))
+    }
 }
 
 /// Extension trait for [`ShapeBundle`] to enable creation of bundles for disc type shapes.
 pub trait DiscBundle {
     fn circle(config: &ShapeConfig, radius: f32) -> Self;
     fn arc(config: &ShapeConfig, radius: f32, start_angle: f32, end_angle: f32) -> Self;
+    fn ellipse(config: &ShapeConfig, extents: Vec2) -> Self;
 }
 
 impl DiscBundle for ShapeBundle<Disc> {
@@ -229,6 +291,10 @@ impl DiscBundle for ShapeBundle<Disc> {
 
     fn arc(config: &ShapeConfig, radius: f32, start_angle: f32, end_angle: f32) -> Self {
         Self::new(config, Disc::arc(config, radius, start_angle, end_angle))
+    }
+
+    fn ellipse(config: &ShapeConfig, extents: Vec2) -> Self {
+        Self::new(config, Disc::ellipse(self.config(), extents))
     }
 }
 
@@ -241,6 +307,7 @@ pub trait DiscSpawner<'w, 's> {
         start_angle: f32,
         end_angle: f32,
     ) -> ShapeEntityCommands<'w, 's, '_>;
+    fn ellipse(&mut self, extents: Vec2) -> ShapeEntityCommands<'w, 's, '_>;
 }
 
 impl<'w, 's, T: ShapeSpawner<'w, 's>> DiscSpawner<'w, 's> for T {
@@ -260,5 +327,8 @@ impl<'w, 's, T: ShapeSpawner<'w, 's>> DiscSpawner<'w, 's> for T {
             start_angle,
             end_angle,
         ))
+    }
+    fn ellipse(&mut self, extents: Vec2) -> ShapeEntityCommands<'w, 's, '_> {
+        self.spawn_shape(ShapeBundle::ellipse(self.config(), extents))
     }
 }


### PR DESCRIPTION
This PR adds relatively simple Ellipse functions in the disc module. These work by modifying the Transform.scale such that the circle is scaled to be a ellipse of the expected size.

This is multiplicative with the existing scale set by the user, which is the behaviour i think most would suspect: scaling a ellipse has the correct effect in relation to other shapes.

![image](https://github.com/james-j-obrien/bevy_vector_shapes/assets/24855949/3b1d3cd1-2d2e-4420-803b-cb30dffc4a82)
> (2 ellipses in black, with red circles to measure whether the correct scaling was applied. the big red circle is the longer dimension of each, the smaller red circles are the smaller dimension of each)

I've only tested the immediate mode variant, but see no reason both shouldn't work.