### PR TITLE
Fix shader error for disc rounded caps alpha

### DIFF
--- a/src/render/shaders/shapes/disc.wgsl
+++ b/src/render/shaders/shapes/disc.wgsl
@@ -117,7 +117,7 @@ fn fragment(f: FragmentInput) -> @location(0) vec4<f32> {
         var dist = length(end_point - f.uv);
 
         var mask = core::step_aa(dist, f.thickness / 2.0);
-        in_shape = min(max(in_shape, mask), 1.0);
+        in_shape = min(max(in_shape, mask), f.color.a);
     }
 
     var color = core::color_output(vec4<f32>(f.color.rgb, in_shape));


### PR DESCRIPTION
Hello! Here is a quick bug fix we made for our project.
@EliottGaboreau

Before:
![alpha_before](https://github.com/james-j-obrien/bevy_vector_shapes/assets/12149055/6fcbd9aa-6e65-472b-9e15-a84d77e6f827)

After:
![alpha_after](https://github.com/james-j-obrien/bevy_vector_shapes/assets/12149055/9911900b-23b3-4f40-81ed-9fc187f11985)
