### PR TITLE
Pass `RenderLayers` from commands interface

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -212,7 +212,7 @@ impl From<&ShapeConfig> for ShapePipelineMaterial {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd)]
-struct RenderLayersHash(RenderLayers);
+pub struct RenderLayersHash(pub RenderLayers);
 
 impl Hash for RenderLayersHash {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/src/render/render_3d.rs
+++ b/src/render/render_3d.rs
@@ -58,8 +58,20 @@ pub fn extract_shapes_3d<T: ShapeData>(
     entities
         .iter()
         .filter_map(|(e, cp, tf, vis, flags, rl)| {
+            let render_layers = match flags {
+                Some(flags) => flags.render_layers.0,
+                None => match rl {
+                    Some(rl) => *rl,
+                    None => RenderLayers::default(),
+                },
+            };
+
             if vis.get() {
-                Some((e, ShapePipelineMaterial::new(flags, rl), cp.get_data(tf)))
+                Some((
+                    e,
+                    ShapePipelineMaterial::new(flags, Some(&render_layers)),
+                    cp.get_data(tf),
+                ))
             } else {
                 None
             }

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -1,6 +1,9 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, render::view::RenderLayers};
 
-use crate::{prelude::*, render::ShapePipelineType};
+use crate::{
+    prelude::*,
+    render::{RenderLayersHash, ShapePipelineType},
+};
 
 mod disc;
 pub use disc::*;
@@ -30,6 +33,8 @@ pub struct ShapeMaterial {
     pub canvas: Option<Entity>,
     /// Texture to apply to the shape.
     pub texture: Option<Handle<Image>>,
+    /// Render layers to use when rendering.
+    pub render_layers: RenderLayersHash,
 }
 
 impl Default for ShapeMaterial {
@@ -40,6 +45,7 @@ impl Default for ShapeMaterial {
             pipeline: ShapePipelineType::Shape2d,
             texture: None,
             canvas: None,
+            render_layers: RenderLayersHash(RenderLayers::default()),
         }
     }
 }
@@ -68,6 +74,7 @@ impl<T: Component> ShapeBundle<T> {
                 pipeline: config.pipeline,
                 canvas: config.canvas,
                 texture: config.texture.clone(),
+                render_layers: RenderLayersHash(config.render_layers.unwrap_or_default()),
             },
             shape_type: component,
         }


### PR DESCRIPTION
`RenderLayers` didn't seem to propagate correctly when using the `commands.spawn` interface.  So I have attempt to push it down to where it needs to be in the `render_3d` file.  I am sorta new to Rust, please make suggestions!

See https://github.com/james-j-obrien/bevy_vector_shapes/issues/34 for more info