### PR TITLE
Implement shape origins

### DIFF
--- a/examples/origin.rs
+++ b/examples/origin.rs
@@ -24,7 +24,7 @@ fn setup(mut commands: Commands) {
 
 fn draw(mut painter: ShapePainter) {
     // Render the background
-    painter.color = Color::BLACK.with_a(0.9);
+    painter.color = Color::BLACK.with_alpha(0.9);
     painter.corner_radii = Vec4::splat(0.1);
     painter.rect(Vec2::new(2.0, 1.0));
 

--- a/examples/origin.rs
+++ b/examples/origin.rs
@@ -1,0 +1,45 @@
+// Demonstrates overriding the origin of a shape so that it is rendered in the correct order.
+
+use bevy::prelude::*;
+use bevy_vector_shapes::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // Add the 3D shape plugin
+        .add_plugins(ShapePlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, draw)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    // Spawn the camera
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_translation(Vec3::new(0.5, 0.3, 2.0))
+            .looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+}
+
+fn draw(mut painter: ShapePainter) {
+    // Render the background
+    painter.color = Color::BLACK.with_a(0.9);
+    painter.corner_radii = Vec4::splat(0.1);
+    painter.rect(Vec2::new(2.0, 1.0));
+
+    // Set the circle color
+    painter.color = Color::WHITE;
+
+    // Set the origin of the circles in front of the background
+    // Without this, the left circle is blended in the wrong order
+    painter.origin = Some(Vec3::Z * 0.01);
+
+    // Render the left circle
+    painter.set_translation(Vec3::X * -0.5);
+    painter.circle(0.2);
+
+    // Render the right circle
+    painter.set_translation(Vec3::X * 0.5);
+    painter.circle(0.2);
+}

--- a/src/painter/config.rs
+++ b/src/painter/config.rs
@@ -15,6 +15,13 @@ pub struct ShapeConfig {
     pub transform: Transform,
     pub alignment: Alignment,
 
+    /// When in 3D, overrides the point in global space that is used to determine the draw order of spawned shapes.
+    ///
+    /// Can be modified to ensure that complex 3D UIs layer properly at oblique camera angles.
+    ///
+    /// Defaults to `None`.
+    pub origin: Option<Vec3>,
+
     pub color: Color,
 
     /// If true spawned shape will have a [`ShapeFill`] with [`FillType::Stroke`], taking into account thickness and thickness_type.
@@ -119,6 +126,7 @@ impl ShapeConfig {
     pub fn default_2d() -> Self {
         Self {
             transform: default(),
+            origin: None,
 
             color: Color::GRAY,
             thickness: 0.1,

--- a/src/painter/shape_painter.rs
+++ b/src/painter/shape_painter.rs
@@ -24,15 +24,20 @@ pub struct ShapeStorage {
 impl ShapeStorage {
     fn send<T: ShapeData>(&mut self, config: &ShapeConfig, data: T) {
         let key = (TypeId::of::<T>(), config.pipeline);
-        let entry = (ShapePipelineMaterial::from(config), data);
         let vec = self
             .shapes
             .entry(key)
             .or_insert_with(AnyVec::new::<ShapeInstance<T>>);
 
+        let instance = ShapeInstance {
+            material: ShapePipelineMaterial::from(config),
+            origin: config.origin.unwrap_or(config.transform.translation),
+            data,
+        };
+
         // SAFETY: we only insert entries in this function and only those that match the appropriate TypeId
         unsafe {
-            vec.downcast_mut_unchecked().push(entry);
+            vec.downcast_mut_unchecked().push(instance);
         }
     }
 

--- a/src/render/commands.rs
+++ b/src/render/commands.rs
@@ -182,7 +182,7 @@ impl<const I: usize, T: ShapeData, P: PhaseItem> RenderCommand<P>
         (bind_groups, instances): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let Some(material) = instances.get(&item.entity()).map(|i| &i.0) else {
+        let Some(material) = instances.get(&item.entity()).map(|i| &i.material) else {
             return RenderCommandResult::Success;
         };
         if let Some(handle) = &material.texture {
@@ -214,7 +214,7 @@ impl<const I: usize, T: ShapeData, P: PhaseItem> RenderCommand<P>
         (bind_groups, instances): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let Some(material) = instances.get(&item.entity()).map(|i| &i.0) else {
+        let Some(material) = instances.get(&item.entity()).map(|i| &i.material) else {
             return RenderCommandResult::Success;
         };
         if let Some(handle) = &material.texture {

--- a/src/render/pipeline.rs
+++ b/src/render/pipeline.rs
@@ -333,7 +333,7 @@ impl<T: ShapeData> GetBatchData for Shape2dPipeline<T> {
         entity: Entity,
     ) -> Option<(Self::BufferData, Option<Self::CompareData>)> {
         let instance = instances.get(&entity)?;
-        Some((instance.1.clone(), Some(instance.0.clone())))
+        Some((instance.data.clone(), Some(instance.material.clone())))
     }
 }
 
@@ -356,6 +356,6 @@ impl<T: ShapeData> GetBatchData for Shape3dPipeline<T> {
         entity: Entity,
     ) -> Option<(Self::BufferData, Option<Self::CompareData>)> {
         let instance = instances.get(&entity)?;
-        Some((instance.1.clone(), Some(instance.0.clone())))
+        Some((instance.data.clone(), Some(instance.material.clone())))
     }
 }

--- a/src/render/render_3d.rs
+++ b/src/render/render_3d.rs
@@ -166,7 +166,7 @@ pub fn queue_shapes_3d<T: ShapeData>(
             let rangefinder = view.rangefinder3d();
             for &entity in entities {
                 // SAFETY: we insert this alongside inserting into the vector we are currently iterating
-                let (_, instance) = unsafe { instance_data.get(&entity).unwrap_unchecked() };
+                let instance = unsafe { instance_data.get(&entity).unwrap_unchecked() };
                 let data = &instance.data;
                 let dist_point = data.transform().transform_vector3(instance.origin);
                 let distance = rangefinder.distance_translation(&dist_point);

--- a/src/render/render_3d.rs
+++ b/src/render/render_3d.rs
@@ -46,6 +46,7 @@ pub fn extract_shapes_3d<T: ShapeData>(
                 &InheritedVisibility,
                 Option<&ShapeMaterial>,
                 Option<&RenderLayers>,
+                Option<&ShapeOrigin>,
             ),
             With<Shape3d>,
         >,
@@ -59,27 +60,40 @@ pub fn extract_shapes_3d<T: ShapeData>(
 
     entities
         .iter()
-        .filter_map(|(e, cp, fill, tf, vis, flags, rl)| {
+        .filter_map(|(e, cp, fill, tf, vis, flags, rl, or)| {
             if vis.get() {
+                // find global origin of shape
+                let local_origin = or.map(|or| or.0).unwrap_or(Vec3::ZERO);
+                let origin = tf.transform_point(local_origin);
+
                 Some((
                     e,
-                    ShapePipelineMaterial::new(flags, rl),
-                    cp.get_data(tf, fill),
+                    ShapeInstance {
+                        material: ShapePipelineMaterial::new(flags, rl),
+                        origin,
+                        data: cp.get_data(tf, fill),
+                    },
                 ))
             } else {
                 None
             }
         })
-        .for_each(|(entity, material, data)| {
-            materials.entry(material.clone()).or_default().push(entity);
-            instance_data.insert(entity, (material, data));
+        .for_each(|(entity, instance)| {
+            materials
+                .entry(instance.material.clone())
+                .or_default()
+                .push(entity);
+            instance_data.insert(entity, instance);
         });
 
     if let Some(iter) = storage.get::<T>(ShapePipelineType::Shape3d) {
-        iter.cloned().for_each(|(material, data)| {
+        iter.cloned().for_each(|instance| {
             let entity = commands.spawn_empty().id();
-            materials.entry(material.clone()).or_default().push(entity);
-            instance_data.insert(entity, (material, data));
+            materials
+                .entry(instance.material.clone())
+                .or_default()
+                .push(entity);
+            instance_data.insert(entity, instance);
         });
     }
 }
@@ -142,8 +156,10 @@ pub fn queue_shapes_3d<T: ShapeData>(
             let rangefinder = view.rangefinder3d();
             for &entity in entities {
                 // SAFETY: we insert this alongside inserting into the vector we are currently iterating
-                let (_, data) = unsafe { instance_data.get(&entity).unwrap_unchecked() };
-                let distance = rangefinder.distance(&data.transform());
+                let instance = unsafe { instance_data.get(&entity).unwrap_unchecked() };
+                let data = &instance.data;
+                let dist_point = data.transform().transform_vector3(instance.origin);
+                let distance = rangefinder.distance_translation(&dist_point);
                 match material.alpha_mode.0 {
                     AlphaMode::Opaque => {
                         opaque_phase.add(Opaque3d {

--- a/src/render/shaders/shapes/line.wgsl
+++ b/src/render/shaders/shapes/line.wgsl
@@ -73,7 +73,8 @@ fn vertex(v: Vertex) -> VertexOutput {
     var origin = select(world_end, world_start, vertex.y < 0.0);
 
     // Calculate the remainder of our basis vectors
-    var basis_vectors = core::get_basis_vectors_from_up(matrix, origin, y_basis, core,:: f_alignment(shape.flags) << 1u);
+    var alignment = core::f_alignment(shape.flags) << 1u;
+    var basis_vectors = core::get_basis_vectors_from_up(matrix, origin, y_basis, alignment);
 
     // Calculate thickness data
     var thickness_type = core::f_thickness_type(shape.flags);
@@ -170,10 +171,10 @@ fn fragment(f: FragmentInput) -> @location(0) vec4<f32> {
         var dist = length(pos);
 
         // Mask out corners
-        in_shape = min(in_shape, core,:: step_aa(dist, 1.));
+        in_shape = min(in_shape, core::step_aa(dist, 1.));
     } else {
         // Simple rectangle sdf for no caps or square caps
-        in_shape = min(in_shape, core,:: step_aa(abs(f.uv.x), 1.) * core,:: step_aa(abs(f.uv.y), 1.0));
+        in_shape = min(in_shape, core::step_aa(abs(f.uv.x), 1.) * core::step_aa(abs(f.uv.y), 1.0));
     }
 
     var color = core::color_output(vec4<f32>(f.color.rgb, in_shape));

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -80,6 +80,12 @@ impl ShapeFill {
 #[derive(Component)]
 pub struct Shape3d;
 
+/// Overrides the origin of a 3D shape so that transparent drawing order can be overridden.
+///
+/// This is in local space.
+#[derive(Component)]
+pub struct ShapeOrigin(pub Vec3);
+
 /// Bundle that is required to render a shape.
 ///
 /// Shape specific methods will additionally add the component representing the corresponding shape.


### PR DESCRIPTION
Transparent 3D shapes are ordered based on their transforms' origins, which in most cases is just the center of the shape. This causes an issue when you view overlapped shapes at an angle:

![oops](https://github.com/james-j-obrien/bevy_vector_shapes/assets/56894066/f13a1b88-ff91-4373-8b31-20647214f4ee)

In this screenshot, the black rectangle is *technically* "behind" the left circle, but because its center is closer to the camera than the left circle's, it is drawn on top of it and the circle is blended out-of-order.

I can definitely imagine this being an issue in 3D games with UIs that have multiple layered elements on top of each other, since the blending order of those elements is dependent on the viewing angle.

My solution to this was to add an API that can override the origin of each shape. The `ShapePainter` API does this with an optional `origin`  in global space for manual painting and the `ShapeOrigin` component enables this in local space for shape entities.

![tada](https://github.com/james-j-obrien/bevy_vector_shapes/assets/56894066/62465225-b584-4ce8-9edb-62d098b5cb05)

tadaaaa

Adding origin info to `ShapePipelineMaterial` and didn't seem appropriate and the GPU had no use for origin data being packed into `ShapeData`, so I decided to turn `ShapeInstance` from a tuple alias into a struct and added the world-space origin as a field.

The screenshots I've added are of the example I've committed.

As far as I can tell, everything else is still working correctly.

Please let me know if I can do anything to improve this!