### PR TITLE
Derive Reflect for all public components

### DIFF
--- a/src/painter/canvas.rs
+++ b/src/painter/canvas.rs
@@ -47,7 +47,7 @@ pub fn update_canvases(
 }
 
 /// Enum that determines when canvases are cleared and redrawn.
-#[derive(Default)]
+#[derive(Default, Reflect)]
 pub enum CanvasMode {
     /// Always clear and draw each frame
     #[default]
@@ -61,7 +61,7 @@ pub enum CanvasMode {
 /// Component containing data and methods for a given canvas.
 ///
 /// Can be spawned as part of a [`CanvasBundle`] with [`CanvasCommands::spawn_canvas`].
-#[derive(Component)]
+#[derive(Component, Reflect)]
 pub struct Canvas {
     /// Handle to the canvas' target texture.
     pub image: Handle<Image>,

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -96,7 +96,7 @@ impl ShapeFill {
 }
 
 /// Marker component for entities that should be drawn by the 3D pipeline.
-#[derive(Component, Reflect)]
+#[derive(Component, Default, Reflect)]
 pub struct Shape3d;
 
 /// Overrides the origin of a 3D shape so that transparent drawing order can be overridden.

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -18,7 +18,7 @@ mod triangle;
 pub use triangle::*;
 
 /// Component that holds data related to a shape to be used during rendering,
-#[derive(Component, Clone)]
+#[derive(Component, Clone, Reflect)]
 pub struct ShapeMaterial {
     /// Alpha mode to use when rendering, Blend, Add and Multiply are explicitly supported.
     pub alpha_mode: ShapeAlphaMode,
@@ -64,7 +64,7 @@ impl From<AlphaMode> for ShapeAlphaMode {
 }
 
 /// Used in [`ShapeFill`] to determine how a shape is rendered.
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, Reflect)]
 pub enum FillType {
     /// Fully colored shape
     #[default]
@@ -76,7 +76,7 @@ pub enum FillType {
 }
 
 /// Component attached to each shape to determine how it is rendered.
-#[derive(Default, Component, Clone, Copy)]
+#[derive(Default, Component, Clone, Copy, Reflect)]
 pub struct ShapeFill {
     pub color: Color,
     pub ty: FillType,
@@ -96,13 +96,13 @@ impl ShapeFill {
 }
 
 /// Marker component for entities that should be drawn by the 3D pipeline.
-#[derive(Component)]
+#[derive(Component, Reflect)]
 pub struct Shape3d;
 
 /// Overrides the origin of a 3D shape so that transparent drawing order can be overridden.
 ///
 /// This is in local space.
-#[derive(Component)]
+#[derive(Component, Reflect)]
 pub struct ShapeOrigin(pub Vec3);
 
 /// Bundle that is required to render a shape.


### PR DESCRIPTION
Working on a project that uses `Reflect` for scripting and noticed that these components didn't implement it. I'd also like to politely request that you publish this change as a patch version on v0.8 so that I can use this without switching to a Git dep. :)