### PR TITLE
Fix WASM with proper shader defs

### DIFF
--- a/src/render/commands.rs
+++ b/src/render/commands.rs
@@ -309,12 +309,6 @@ impl<P: PhaseItem, T: ShapeData> RenderCommand<P> for DrawShape<T> {
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let batch_range = item.batch_range();
-        #[cfg(all(feature = "webgl", target_arch = "wasm32"))]
-        pass.set_push_constants(
-            ShaderStages::VERTEX,
-            0,
-            &(batch_range.start as i32).to_le_bytes(),
-        );
         pass.set_vertex_buffer(0, quad.into_inner().buffer.slice(..));
         pass.draw(0..T::VERTICES, batch_range.clone());
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -82,7 +82,7 @@ pub fn load_shaders(app: &mut App) {
         Shader::from_wgsl_with_defs,
         defs
     );
-    let defs = NgonData::shader_defs(app);
+    let defs = LineData::shader_defs(app);
     load_internal_asset!(
         app,
         LINE_HANDLE,
@@ -106,11 +106,13 @@ pub fn load_shaders(app: &mut App) {
         Shader::from_wgsl_with_defs,
         defs
     );
+    let defs = TriangleData::shader_defs(app);
     load_internal_asset!(
         app,
         TRIANGLE_HANDLE,
         "shaders/shapes/tri.wgsl",
-        Shader::from_wgsl
+        Shader::from_wgsl_with_defs,
+        defs
     );
 }
 


### PR DESCRIPTION
Hello there. Rendering lines or triangles crashes WASM during pipeline validation. It seems to me its caused by typos in the code.

Also there's a `#[cfg]` which does nothing, because the `webgl` feature does not exist, so I removed it.