### PR TITLE
Migrate internal usage of bundles to required components

### DIFF
--- a/examples/alpha_mode.rs
+++ b/examples/alpha_mode.rs
@@ -18,18 +18,18 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_translation(Vec3::Z),
-        projection: OrthographicProjection {
+    commands.spawn((
+        Camera2d,
+        Transform::from_translation(Vec3::Z),
+        OrthographicProjection {
             scaling_mode: ScalingMode::AutoMin {
                 min_width: 5.2 * 4.5,
                 min_height: 3.2 * 4.5,
             },
             ..OrthographicProjection::default_2d()
         },
-        msaa: Msaa::Off,
-        ..default()
-    });
+        Msaa::Off,
+    ));
 }
 
 fn draw_circles(painter: &mut ShapePainter, radius: f32) {

--- a/examples/billboard.rs
+++ b/examples/billboard.rs
@@ -24,10 +24,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((Camera3d::default(), Msaa::Off));
 }
 
 fn draw_gallery(

--- a/examples/bloom.rs
+++ b/examples/bloom.rs
@@ -1,6 +1,6 @@
 // Demonstrates shapes respecting global bloom settings
 
-use bevy::core_pipeline::bloom::BloomSettings;
+use bevy::core_pipeline::bloom::Bloom;
 use bevy::prelude::*;
 use bevy_vector_shapes::prelude::*;
 
@@ -19,16 +19,14 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     commands.spawn((
-        Camera3dBundle {
-            camera: Camera {
-                hdr: true,
-                ..default()
-            },
-            transform: Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
-            msaa: Msaa::Off,
+        Camera3d::default(),
+        Camera {
+            hdr: true,
             ..default()
         },
-        BloomSettings::default(),
+        Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+        Bloom::default(),
     ));
 }
 

--- a/examples/bundles.rs
+++ b/examples/bundles.rs
@@ -14,11 +14,11 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn((Camera3dBundle {
-        transform: Transform::from_xyz(0., 0.0, 16.).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    },));
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0.0, 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 
     // Note: [`ShapeBundle`] does not include `RenderLayers` by default so the associated field
     // on [`ShapeConfig`] will be ignored, add the component manually or use [`ShapeCommands::rect`]

--- a/examples/canvas_basic.rs
+++ b/examples/canvas_basic.rs
@@ -20,11 +20,11 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     let config = CanvasConfig::new(1024, 1024);
     commands.spawn_canvas(images.as_mut(), config);
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 }
 
 fn draw_shapes(time: Res<Time>, mut painter: ShapePainter, canvas: Query<(Entity, &Canvas)>) {

--- a/examples/canvas_bloom.rs
+++ b/examples/canvas_bloom.rs
@@ -2,7 +2,7 @@
 // Note you will still get some bloom effects even without an HDR canvas,
 // but in order to allow for color values below 1.0 the canvas needs HDR enabled
 
-use bevy::{core_pipeline::bloom::BloomSettings, image::ImageSampler, prelude::*};
+use bevy::{core_pipeline::bloom::Bloom, image::ImageSampler, prelude::*};
 use bevy_vector_shapes::prelude::*;
 
 mod gallery_3d;
@@ -28,16 +28,14 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     commands.spawn_canvas(images.as_mut(), config);
 
     commands.spawn((
-        Camera3dBundle {
-            camera: Camera {
-                hdr: true,
-                ..default()
-            },
-            transform: Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
-            msaa: Msaa::Off,
+        Camera3d::default(),
+        Camera {
+            hdr: true,
             ..default()
         },
-        BloomSettings::default(),
+        Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+        Bloom::default(),
     ));
 }
 

--- a/examples/canvas_low_res.rs
+++ b/examples/canvas_low_res.rs
@@ -24,11 +24,11 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     config.sampler = ImageSampler::nearest();
     commands.spawn_canvas(images.as_mut(), config);
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 }
 
 fn draw_shapes(time: Res<Time>, mut painter: ShapePainter, canvas: Query<(Entity, &Canvas)>) {

--- a/examples/canvas_modes.rs
+++ b/examples/canvas_modes.rs
@@ -18,11 +18,11 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     let config = CanvasConfig::new(1024, 1024);
     commands.spawn_canvas(images.as_mut(), config);
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 }
 
 fn update_canvas(keys: Res<ButtonInput<KeyCode>>, mut canvas: Query<&mut Canvas>) {

--- a/examples/canvas_recursion.rs
+++ b/examples/canvas_recursion.rs
@@ -17,11 +17,11 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     let config = CanvasConfig::new(1024, 1024);
     commands.spawn_canvas(images.as_mut(), config);
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 }
 
 fn draw_shapes(time: Res<Time>, mut painter: ShapePainter, canvas: Query<(Entity, &Canvas)>) {

--- a/examples/gallery_2d.rs
+++ b/examples/gallery_2d.rs
@@ -17,10 +17,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle {
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((Camera2d, Msaa::Off));
 }
 
 fn draw_gallery(time: Res<Time>, mut painter: ShapePainter) {

--- a/examples/gallery_3d.rs
+++ b/examples/gallery_3d.rs
@@ -345,13 +345,12 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands
-        .spawn(Camera3dBundle {
-            transform: Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
-            msaa: Msaa::Off,
-            ..default()
-        })
-        .insert(RenderLayers::default());
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+        RenderLayers::default(),
+    ));
 }
 
 fn draw_gallery(time: Res<Time>, painter: ShapePainter) {

--- a/examples/healthbar_stress_test.rs
+++ b/examples/healthbar_stress_test.rs
@@ -24,11 +24,11 @@ fn main() {
 fn setup(mut commands: Commands) {
     let shapes = SHAPES_PER_AXIS as f32;
     let center = Vec3::new(shapes, 0.0, shapes);
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-20.0, 20.0, -20.0).looking_at(center, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-20.0, 20.0, -20.0).looking_at(center, Vec3::Y),
+        Msaa::Off,
+    ));
 }
 
 fn draw_health_bar(painter: &mut ShapePainter, hp: f32) {

--- a/examples/minimal_2d.rs
+++ b/examples/minimal_2d.rs
@@ -15,7 +15,7 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     // Spawn the camera
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }
 
 fn draw(mut painter: ShapePainter) {

--- a/examples/minimal_3d.rs
+++ b/examples/minimal_3d.rs
@@ -15,7 +15,7 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     // Spawn the camera
-    commands.spawn(Camera3dBundle::default());
+    commands.spawn(Camera3d::default());
 }
 
 fn draw(mut painter: ShapePainter) {

--- a/examples/origin.rs
+++ b/examples/origin.rs
@@ -15,11 +15,10 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     // Spawn the camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(0.5, 0.3, 2.0))
-            .looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.5, 0.3, 2.0)).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }
 
 fn draw(mut painter: ShapePainter) {

--- a/examples/parenting_commands.rs
+++ b/examples/parenting_commands.rs
@@ -22,19 +22,19 @@ fn main() {
 struct Target;
 
 fn setup(mut commands: Commands, mut shapes: ShapeCommands, mut meshes: ResMut<Assets<Mesh>>) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 0.0, 16.).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0.0, 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 
     // When spawning shapes as children of non-shape entities you can use `with_shape_children`
     // This requires passing in a ShapeConfig, you can construct one yourself or
     // take an existing one from a ShapePainter or ShapeCommands with .config()
     commands
-        .spawn((Target, SpatialBundle::default()))
+        .spawn((Target, Transform::default(), Visibility::default()))
         .with_shape_children(shapes.config(), |child_builder| {
-            for _ in 0..4 {
+            for _ in 0..1 {
                 child_builder.rotate_z(PI / 2.0);
                 child_builder.line(Vec3::Y, Vec3::Y * 2.0);
             }
@@ -45,18 +45,18 @@ fn setup(mut commands: Commands, mut shapes: ShapeCommands, mut meshes: ResMut<A
     // When spawning non-shapes as children of shapes you can use `with_children` like normal
     shapes
         .circle(0.2)
-        .insert(Target)
+        .insert((Target, Transform::default(), Visibility::default()))
         .with_children(|child_builder| {
             for i in 0..4 {
                 let transform = Transform::from_translation(
                     Quat::from_rotation_z(PI / 2.0 * i as f32 + PI / 4.0)
                         * Vec3::new(0.0, 1.0, 0.0),
                 );
-                child_builder.spawn(PbrBundle {
-                    mesh: cube_handle.clone().into(),
+                child_builder.spawn((
+                    Mesh3d(cube_handle.clone()),
+                    MeshMaterial3d::<StandardMaterial>::default(),
                     transform,
-                    ..default()
-                });
+                ));
             }
         });
 }

--- a/examples/parenting_painter.rs
+++ b/examples/parenting_painter.rs
@@ -17,16 +17,17 @@ fn main() {
 struct Tree;
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 
     // Immediate mode shapes don't need to be parented to an entity but we do so here to demonstrate how
     commands.spawn((
         Tree,
-        SpatialBundle::from_transform(Transform::from_xyz(0.0, -5.0, 0.0)),
+        Transform::from_xyz(0.0, -5.0, 0.0),
+        Visibility::default(),
     ));
 }
 

--- a/examples/render_layers.rs
+++ b/examples/render_layers.rs
@@ -39,25 +39,22 @@ fn setup(
 
     // Light
     // NOTE: Currently lights are shared between passes - see https://github.com/bevyengine/bevy/issues/3462
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
-        ..default()
-    });
+    commands.spawn((
+        PointLight::default(),
+        Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
+    ));
 
     commands.spawn((
-        Camera3dBundle {
-            camera: Camera {
-                clear_color: ClearColorConfig::Custom(Color::WHITE),
-                // render before the "main pass" camera
-                order: -1,
-                target: RenderTarget::Image(image_handle.clone()),
-                ..default()
-            },
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
-                .looking_at(Vec3::ZERO, Vec3::Y),
-            msaa: Msaa::Off,
+        Camera3d::default(),
+        Camera {
+            clear_color: ClearColorConfig::Custom(Color::WHITE),
+            // render before the "main pass" camera
+            order: -1,
+            target: RenderTarget::Image(image_handle.clone()),
             ..default()
         },
+        Transform::from_translation(Vec3::new(0.0, 0.0, 15.0)).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
         first_pass_layer,
     ));
 
@@ -74,22 +71,18 @@ fn setup(
 
     // Main pass cube, with material containing the rendered first pass texture.
     commands.spawn((
-        PbrBundle {
-            mesh: cube_handle.into(),
-            material: material_handle.into(),
-            transform: Transform::from_xyz(0.0, 0.0, 1.5)
-                .with_rotation(Quat::from_rotation_x(-PI / 5.0)),
-            ..default()
-        },
+        Mesh3d(cube_handle),
+        MeshMaterial3d(material_handle),
+        Transform::from_xyz(0.0, 0.0, 1.5).with_rotation(Quat::from_rotation_x(-PI / 5.0)),
         MainPassCube,
     ));
 
     // The main pass camera.
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 0.0, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 }
 
 fn draw_shapes(time: Res<Time>, mut painter: ShapePainter) {

--- a/examples/retained.rs
+++ b/examples/retained.rs
@@ -16,11 +16,11 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, mut shapes: ShapeCommands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 0.0, 16.).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0.0, 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 
     // The ShapeCommands API is identical to the ShapePainter API so can be used almost interchangeably
     shapes.circle(1.0).with_children(|parent| {

--- a/examples/textured.rs
+++ b/examples/textured.rs
@@ -22,11 +22,11 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     config.clear_color = ClearColorConfig::Custom((WHITE * 0.5).into());
     let (_, _entity) = commands.spawn_canvas(images.as_mut(), config);
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 0., 16.).looking_at(Vec3::ZERO, Vec3::Y),
+        Msaa::Off,
+    ));
 }
 
 fn draw_canvas(time: Res<Time>, mut painter: ShapePainter, canvas: Query<(Entity, &Canvas)>) {

--- a/examples/thickness.rs
+++ b/examples/thickness.rs
@@ -14,10 +14,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        msaa: Msaa::Off,
-        ..default()
-    });
+    commands.spawn((Camera3d::default(), Msaa::Off));
 }
 
 fn draw_gallery(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,19 +11,21 @@
 
 //! fn main() {
 //!     App::new()
-//!         .add_plugins(DefaultPlugins)
-//!         // Add the shape plugin:
-//!         // - Shape2dPlugin for 2D cameras
-//!         // - ShapePlugin for both 3D and 2D cameras
-//!         .add_plugins(Shape2dPlugin::default())
-//!         .add_startup_system(setup)
-//!         .add_system(draw)
+//!         .add_plugins((
+//!             DefaultPlugins,
+//!             // Add the shape plugin:
+//!             // - Shape2dPlugin for 2D cameras
+//!             // - ShapePlugin for both 3D and 2D cameras
+//!             Shape2dPlugin::default(),
+//!         ))
+//!         .add_systems(Startup, setup)
+//!         .add_systems(Update, draw)
 //!         .run();
 //! }
 
 //! fn setup(mut commands: Commands) {
 //!     // Spawn the camera
-//!     commands.spawn(Camera2dBundle::default());
+//!     commands.spawn(Camera2d);
 //! }
 
 //! fn draw(mut painter: ShapePainter) {

--- a/src/painter/canvas.rs
+++ b/src/painter/canvas.rs
@@ -181,7 +181,8 @@ impl CanvasConfig {
 /// Can be spawned with [`CanvasCommands::spawn_canvas`].
 #[derive(Bundle)]
 pub struct CanvasBundle {
-    camera: Camera2dBundle,
+    camera_2d: Camera2d,
+    camera: Camera,
     canvas: Canvas,
     render_layers: RenderLayers,
 }
@@ -190,15 +191,12 @@ impl CanvasBundle {
     /// Create a [`CanvasBundle`] from a given image with the given configuration.
     pub fn new(image: Handle<Image>, config: CanvasConfig) -> Self {
         Self {
-            camera: Camera2dBundle {
-                camera_2d: Camera2d,
-                camera: Camera {
-                    order: config.order,
-                    hdr: config.hdr,
-                    target: RenderTarget::Image(image.clone()),
-                    clear_color: config.clear_color,
-                    ..default()
-                },
+            camera_2d: Camera2d,
+            camera: Camera {
+                order: config.order,
+                hdr: config.hdr,
+                target: RenderTarget::Image(image.clone()),
+                clear_color: config.clear_color,
                 ..default()
             },
             canvas: Canvas {

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -110,7 +110,8 @@ pub struct ShapeOrigin(pub Vec3);
 /// Shape specific methods will additionally add the component representing the corresponding shape.
 #[derive(Bundle)]
 pub struct ShapeBundle<T: Component> {
-    pub spatial_bundle: SpatialBundle,
+    pub visibility: Visibility,
+    pub transform: Transform,
     pub shape: ShapeMaterial,
     pub fill: ShapeFill,
     pub shape_type: T,
@@ -119,7 +120,8 @@ pub struct ShapeBundle<T: Component> {
 impl<T: Component> ShapeBundle<T> {
     pub fn new(config: &ShapeConfig, component: T) -> Self {
         Self {
-            spatial_bundle: SpatialBundle::from_transform(config.transform),
+            visibility: default(),
+            transform: config.transform,
             shape: ShapeMaterial {
                 alpha_mode: config.alpha_mode,
                 disable_laa: config.disable_laa,


### PR DESCRIPTION
This migrates all usage of bundles in the library and examples to the equivalent required components. This doesn't touch the bundles provided by the library itself (e.g. `ShapeBundle`, `CanvasBundle`, etc.), which can be done in a separate PR.