### PR TITLE
Fix lints slightly differently

### DIFF
--- a/src/painter/canvas.rs
+++ b/src/painter/canvas.rs
@@ -217,7 +217,7 @@ pub trait CanvasCommands<'w> {
     ///
     /// Returns the created [`Handle<Image>`] and [`EntityCommands`].
     fn spawn_canvas(
-        &'_ mut self,
+        &mut self,
         assets: &mut Assets<Image>,
         config: CanvasConfig,
     ) -> (Handle<Image>, EntityCommands<'_>);
@@ -225,7 +225,7 @@ pub trait CanvasCommands<'w> {
 
 impl<'w, 's> CanvasCommands<'w> for Commands<'w, 's> {
     fn spawn_canvas(
-        &'_ mut self,
+        &mut self,
         assets: &mut Assets<Image>,
         config: CanvasConfig,
     ) -> (Handle<Image>, EntityCommands<'_>) {

--- a/src/painter/child_commands.rs
+++ b/src/painter/child_commands.rs
@@ -74,7 +74,7 @@ pub struct ShapeChildBuilder<'w> {
 impl<'w> ShapeChildBuilder<'w> {
     /// Spawns an entity with the given bundle and inserts it into the parent entity's [`Children`].
     /// Also adds [`Parent`] component to the created entity.
-    pub fn spawn(&'_ mut self, bundle: impl Bundle) -> EntityCommands<'_> {
+    pub fn spawn(&mut self, bundle: impl Bundle) -> EntityCommands<'_> {
         let e = self.commands.spawn(bundle);
         self.push_children.children.push(e.id());
         e
@@ -82,7 +82,7 @@ impl<'w> ShapeChildBuilder<'w> {
 
     /// Spawns an [`Entity`] with no components and inserts it into the parent entity's [`Children`].
     /// Also adds [`Parent`] component to the created entity.
-    pub fn spawn_empty(&'_ mut self) -> EntityCommands<'_> {
+    pub fn spawn_empty(&mut self) -> EntityCommands<'_> {
         let e = self.commands.spawn_empty();
         self.push_children.children.push(e.id());
         e
@@ -101,7 +101,7 @@ impl<'w> ShapeChildBuilder<'w> {
 }
 
 impl<'w> ShapeSpawner<'w> for ShapeChildBuilder<'w> {
-    fn spawn_shape(&'_ mut self, bundle: impl Bundle) -> ShapeEntityCommands<'_, '_> {
+    fn spawn_shape(&mut self, bundle: impl Bundle) -> ShapeEntityCommands<'_, '_> {
         let Self {
             commands, config, ..
         } = self;

--- a/src/painter/mod.rs
+++ b/src/painter/mod.rs
@@ -28,7 +28,7 @@ pub trait ShapeSpawner<'w>: DerefMut<Target = ShapeConfig> {
     /// Note: [`ShapeBundle`](crate::ShapeBundle) does not include [`RenderLayers`](bevy::render::view::RenderLayers) as there is no support for optional components
     /// so instead it is inserted in this function conditionally depending on the [`ShapeConfig`] in `self`
     /// Prefer the function for the shape you want over [`ShapeSpawner::spawn_shape`], e.g. `commands.rect(...)`
-    fn spawn_shape(&'_ mut self, bundle: impl Bundle) -> ShapeEntityCommands<'_, '_>;
+    fn spawn_shape(&mut self, bundle: impl Bundle) -> ShapeEntityCommands<'_, '_>;
 }
 
 /// Plugin that setups up resources and systems for [`Canvas`] and [`ShapePainter`].

--- a/src/painter/shape_commands.rs
+++ b/src/painter/shape_commands.rs
@@ -25,7 +25,7 @@ impl<'w, 's> ShapeCommands<'w, 's> {
 }
 
 impl<'w, 's> ShapeSpawner<'w> for ShapeCommands<'w, 's> {
-    fn spawn_shape(&'_ mut self, bundle: impl Bundle) -> ShapeEntityCommands<'_, '_> {
+    fn spawn_shape(&mut self, bundle: impl Bundle) -> ShapeEntityCommands<'_, '_> {
         let Self {
             commands, config, ..
         } = self;

--- a/src/shapes/disc.rs
+++ b/src/shapes/disc.rs
@@ -234,22 +234,18 @@ impl DiscBundle for ShapeBundle<DiscComponent> {
 
 /// Extension trait for [`ShapeSpawner`] to enable spawning of entities for disc type shapes.
 pub trait DiscSpawner<'w> {
-    fn circle(&'_ mut self, radius: f32) -> ShapeEntityCommands<'_, '_>;
-    fn arc(
-        &'_ mut self,
-        radius: f32,
-        start_angle: f32,
-        end_angle: f32,
-    ) -> ShapeEntityCommands<'_, '_>;
+    fn circle(&mut self, radius: f32) -> ShapeEntityCommands<'_, '_>;
+    fn arc(&mut self, radius: f32, start_angle: f32, end_angle: f32)
+        -> ShapeEntityCommands<'_, '_>;
 }
 
 impl<'w, T: ShapeSpawner<'w>> DiscSpawner<'w> for T {
-    fn circle(&'_ mut self, radius: f32) -> ShapeEntityCommands<'_, '_> {
+    fn circle(&mut self, radius: f32) -> ShapeEntityCommands<'_, '_> {
         self.spawn_shape(ShapeBundle::circle(self.config(), radius))
     }
 
     fn arc(
-        &'_ mut self,
+        &mut self,
         radius: f32,
         start_angle: f32,
         end_angle: f32,

--- a/src/shapes/line.rs
+++ b/src/shapes/line.rs
@@ -159,7 +159,7 @@ impl LineBundle for ShapeBundle<LineComponent> {
 
 /// Extension trait for [`ShapeSpawner`] to enable spawning of line entities.
 pub trait LineSpawner<'w>: ShapeSpawner<'w> {
-    fn line(&'_ mut self, start: Vec3, end: Vec3) -> ShapeEntityCommands<'_, '_>;
+    fn line(&mut self, start: Vec3, end: Vec3) -> ShapeEntityCommands<'_, '_>;
 }
 
 impl<'w, T: ShapeSpawner<'w>> LineSpawner<'w> for T {

--- a/src/shapes/rectangle.rs
+++ b/src/shapes/rectangle.rs
@@ -163,11 +163,11 @@ impl RectangleBundle for ShapeBundle<RectangleComponent> {
 
 /// Extension trait for [`ShapeSpawner`] to enable spawning of rectangle entities.
 pub trait RectangleSpawner<'w> {
-    fn rect(&'_ mut self, size: Vec2) -> ShapeEntityCommands<'_, '_>;
+    fn rect(&mut self, size: Vec2) -> ShapeEntityCommands<'_, '_>;
 }
 
 impl<'w, T: ShapeSpawner<'w>> RectangleSpawner<'w> for T {
-    fn rect(&'_ mut self, size: Vec2) -> ShapeEntityCommands<'_, '_> {
+    fn rect(&mut self, size: Vec2) -> ShapeEntityCommands<'_, '_> {
         self.spawn_shape(ShapeBundle::rect(self.config(), size))
     }
 }

--- a/src/shapes/triangle.rs
+++ b/src/shapes/triangle.rs
@@ -177,11 +177,11 @@ impl TriangleBundle for ShapeBundle<TriangleComponent> {
 
 /// Extension trait for [`ShapeSpawner`] to enable spawning of triangle entities.
 pub trait TriangleSpawner<'w> {
-    fn triangle(&'_ mut self, v_a: Vec2, v_b: Vec2, v_c: Vec2) -> ShapeEntityCommands<'_, '_>;
+    fn triangle(&mut self, v_a: Vec2, v_b: Vec2, v_c: Vec2) -> ShapeEntityCommands<'_, '_>;
 }
 
 impl<'w, T: ShapeSpawner<'w>> TriangleSpawner<'w> for T {
-    fn triangle(&'_ mut self, v_a: Vec2, v_b: Vec2, v_c: Vec2) -> ShapeEntityCommands<'_, '_> {
+    fn triangle(&mut self, v_a: Vec2, v_b: Vec2, v_c: Vec2) -> ShapeEntityCommands<'_, '_> {
         self.spawn_shape(ShapeBundle::triangle(self.config(), v_a, v_b, v_c))
     }
 }


### PR DESCRIPTION
I noticed you added a bunch of `&'_ self` while fixing lints, which is unnecessary. The lint specifically checks for types that have lifetime annotations that are elided completely, which is good and reduces confusion. But `&self` is already elided, so binding it to `_` generates exactly the same lifetimes just with extra noise. It also isn't required by the lint.

(the elision rules for reference: https://doc.rust-lang.org/nomicon/lifetime-elision.html)