### PR TITLE
Fix Adreno crash in 2D rectangle shader

### DIFF
--- a/src/render/shaders/shapes/rect.wgsl
+++ b/src/render/shaders/shapes/rect.wgsl
@@ -81,10 +81,36 @@ fn vertex(v: Vertex) -> VertexOutput {
 #endif
 
 #ifdef PIPELINE_3D
-    let vertex_data = core::get_vertex_data(matrix, vertex.xy * shape.size / 2.0, shape.thickness, shape.flags);
-    out.clip_position = vertex_data.clip_pos;
-    out.uv = vertex.xy * out.size * vertex_data.uv_ratio;
-    out.thickness = core::calculate_thickness(vertex_data.thickness_data, half_shortest_side, shape.flags);
+    let local_position = vertex.xy * shape.size / 2.0;
+    let origin = matrix[3].xyz;
+    let alignment = core::f_alignment(shape.flags);
+
+    var y_basis = normalize(matrix[1].xyz);
+    var z_basis = normalize(matrix[2].xyz);
+    if alignment == 1u {
+        y_basis = normalize((view.view * vec4<f32>(0.0, 1.0, 0.0, 0.0)).xyz);
+        z_basis = normalize(view.world_position - origin);
+    }
+
+    let x_basis = normalize(cross(y_basis, z_basis));
+    y_basis = cross(x_basis, z_basis);
+
+    let scale = core::get_scale(matrix);
+    let scaled_position = local_position * scale;
+    let thickness_data = core::get_thickness_data(
+        shape.thickness,
+        core::f_thickness_type(shape.flags),
+        origin,
+        y_basis,
+    );
+    let aa_padding = core::AA_PADDING / thickness_data.pixels_per_u;
+    let padded_position = scaled_position + sign(local_position) * aa_padding;
+    let uv_ratio = padded_position / scaled_position;
+    let world_position = origin + padded_position.x * x_basis + padded_position.y * y_basis;
+
+    out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
+    out.uv = vertex.xy * out.size * uv_ratio;
+    out.thickness = core::calculate_thickness(thickness_data, half_shortest_side, shape.flags);
 #endif
 
     out.corner_radii = 2.0 * min(shape.corner_radii / shortest_side, vec4<f32>(0.5));

--- a/src/render/shaders/shapes/rect.wgsl
+++ b/src/render/shaders/shapes/rect.wgsl
@@ -1,6 +1,5 @@
 #import bevy_vector_shapes::core
 #import bevy_vector_shapes::core::{view, image, image_sampler}
-#import bevy_vector_shapes::constants::{PI, TAU}
 
 struct Vertex {
     @builtin(instance_index) index: u32,
@@ -43,31 +42,52 @@ struct VertexOutput {
 fn vertex(v: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
-    // Vertex positions for a basic quad
     let vertex = v.pos;
     let shape = shapes[v.index];
-
-    // Reconstruct our transformation matrix
     let matrix = mat4x4<f32>(
         shape.matrix_0,
         shape.matrix_1,
         shape.matrix_2,
         shape.matrix_3
     );
-    // Shortest of the two side lengths for the rectangle
-    var shortest_side = min(shape.size.x, shape.size.y);
+    let shortest_side = min(shape.size.x, shape.size.y);
+    let half_shortest_side = shortest_side / 2.0;
 
-    var vertex_data = core::get_vertex_data(matrix, vertex.xy * shape.size / 2.0, shape.thickness, shape.flags);
-    out.clip_position = vertex_data.clip_pos;
-
-    // Our vertex outputs should all be in uv space so scale our uv space such that the shortest side is of length 1
     out.size = shape.size / shortest_side;
+
+#ifdef PIPELINE_2D
+    let local_position = vertex.xy * shape.size / 2.0;
+    let scale = max(core::get_scale(matrix), vec2<f32>(0.000001));
+    let scaled_position = local_position * scale;
+    let y_axis = matrix[1].xyz;
+    let y_axis_length = length(y_axis);
+    var y_direction = vec3<f32>(0.0, 1.0, 0.0);
+    if y_axis_length > 0.000001 {
+        y_direction = y_axis / y_axis_length;
+    }
+    let thickness_data = core::get_thickness_data(
+        shape.thickness,
+        core::f_thickness_type(shape.flags),
+        matrix[3].xyz,
+        y_direction,
+    );
+    let aa_padding = core::AA_PADDING / thickness_data.pixels_per_u;
+    let padded_local_position = local_position + sign(local_position) * aa_padding / scale;
+    let uv_ratio = (abs(scaled_position) + aa_padding) / max(abs(scaled_position), vec2<f32>(0.000001));
+
+    out.clip_position = view.view_proj * matrix * vec4<f32>(padded_local_position, 0.0, 1.0);
+    out.uv = vertex.xy * out.size * uv_ratio;
+    out.thickness = core::calculate_thickness(thickness_data, half_shortest_side, shape.flags);
+#endif
+
+#ifdef PIPELINE_3D
+    let vertex_data = core::get_vertex_data(matrix, vertex.xy * shape.size / 2.0, shape.thickness, shape.flags);
+    out.clip_position = vertex_data.clip_pos;
     out.uv = vertex.xy * out.size * vertex_data.uv_ratio;
-    out.thickness = core::calculate_thickness(vertex_data.thickness_data, shortest_side / 2.0, shape.flags);
+    out.thickness = core::calculate_thickness(vertex_data.thickness_data, half_shortest_side, shape.flags);
+#endif
 
-    // Our corner radii cannot be more than half the shortest side so cap them
     out.corner_radii = 2.0 * min(shape.corner_radii / shortest_side, vec4<f32>(0.5));
-
     out.color = shape.color;
 #ifdef TEXTURED
     out.texture_uv = core::get_texture_uv(vertex.xy);
@@ -118,30 +138,17 @@ fn quadrant(in: vec2<f32>) -> i32 {
 #ifdef FRAGMENT
 @fragment
 fn fragment(f: FragmentInput) -> @location(0) vec4<f32> {
-    // Mask representing whether this fragment falls within the shape
-    var in_shape = f.color.a;
+    let radius = f.corner_radii[quadrant(f.uv)];
+    let signed_distance = rectSDF(f.uv, f.size - radius) - radius;
+    let alpha = f.color.a
+        * core::step_aa(-f.thickness, signed_distance)
+        * core::step_aa(signed_distance, 0.0);
 
-    // Use quadrant to determine which corner radii to use
-    var quadrant = quadrant(f.uv);
-    var radii = f.corner_radii[quadrant];
+    var color = core::color_output(vec4<f32>(f.color.rgb, alpha));
 
-    // Calculate our positions distance from the rectangle
-    var dist = rectSDF(f.uv, f.size - radii) - radii;
-    
-    // Cut off points outside the shape or within the hollow area
-    in_shape *= core::step_aa(-f.thickness, dist) * core::step_aa(dist, 0.);
-
-
-
-    var color = core::color_output(vec4<f32>(f.color.rgb, in_shape));
 #ifdef TEXTURED
     color = color * textureSample(image, image_sampler, f.texture_uv);
 #endif
-
-    // Discard fragments no longer in the shape
-    if in_shape < 0.0001 {
-        discard;
-    }
 
     return color;
 }


### PR DESCRIPTION
## Summary

This fixes an Android/Adreno Vulkan driver crash when compiling the 2D rectangle shape pipeline.

On a POCO `marble_global` device with an Adreno 725 GPU, the `RectData` alpha-blended 2D pipeline crashed inside the vendor Vulkan driver during pipeline creation:

- `Fatal signal 11 (SIGSEGV), fault addr 0x8`
- thread: `Async Compute T`
- stack: `libllvm-qgl.so` -> `libllvm-glnext.so` -> `vulkan.adreno.so` -> `qglinternal::vkCreateGraphicsPipelines(...)`

This is the same class of Android/Adreno driver failure Bevy has had to work around before, for example:

- https://github.com/bevyengine/bevy/issues/13038
- https://github.com/bevyengine/bevy/pull/13323

## What changed

- Keep the existing 3D rectangle path using `core::get_vertex_data`.
- Add a 2D-specific rectangle vertex path that computes:
  - local position
  - scale
  - anti-aliasing padding
  - UV ratio
  - thickness data
  - clip position
- Preserve `ThicknessType` behavior by still using `core::get_thickness_data` and `core::calculate_thickness`.
- Preserve rounded-corner SDF fragment masking.
- Avoid fragment `discard` in the rectangle shader. For the supported blended shape modes, zero alpha is enough to mask the fragment and avoids another Adreno compiler crash trigger.
- Remove the unused constants import from the rectangle shader.

## Diagnosis

The crash was isolated by progressively simplifying `rect.wgsl` on the affected device:

- Disabling all vector shapes avoided the crash.
- Logging pipeline creation identified `bevy_vector_shapes::shapes::rectangle::RectData` / `alpha_blend_shape_pipeline` as the crashing pipeline.
- Removing only fragment SDF, corner radius lookup, texture sampling, local AA, and `discard` was not enough.
- A constant rectangle vertex shader did not crash.
- Reading the rectangle instance data and color did not crash.
- Reintroducing `core::get_vertex_data(...)` made the crash return.
- A direct 2D rectangle vertex path avoided the crash while keeping the expected rectangle rendering behavior.

## Validation

Validated in a downstream Bevy 0.17 project using this branch:

- `cargo clippy --all-features --all-targets`
- Android debug build on the affected Adreno 725 device
- Automated repro that starts a match and places cards that render vector-shape rectangles
- Repeated repro runs no longer produce the `vkCreateGraphicsPipelines` / `libllvm-qgl.so` SIGSEGV
