### PR TITLE
Harden shape shaders for Adreno Vulkan and WebGL2

### DIFF
--- a/src/render/shaders/shapes/disc.wgsl
+++ b/src/render/shaders/shapes/disc.wgsl
@@ -20,6 +20,7 @@ struct Shape {
     @location(7) radius: f32,
     @location(8) start_angle: f32, 
     @location(9) end_angle: f32,
+    @location(10) padding: vec4<f32>,
 };
 
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
@@ -56,12 +57,42 @@ fn vertex(v: Vertex) -> VertexOutput {
         shape.matrix_3
     );
 
-    var vertex_data = core::get_vertex_data(matrix, vertex.xy * shape.radius, shape.thickness, shape.flags);
+    let local_position = vertex.xy * shape.radius;
+    let origin = matrix[3].xyz;
+    let alignment = core::f_alignment(shape.flags);
 
-    // Multiply the world space position by the view projection matrix to convert to our clip position
-    out.clip_position = vertex_data.clip_pos;
-    out.uv = vertex.xy * vertex_data.uv_ratio;
-    out.thickness = core::calculate_thickness(vertex_data.thickness_data, shape.radius, shape.flags);
+    var y_basis = normalize(matrix[1].xyz);
+    var z_basis = normalize(matrix[2].xyz);
+    if alignment == 1u {
+        y_basis = normalize((view.view * vec4<f32>(0.0, 1.0, 0.0, 0.0)).xyz);
+#ifdef PIPELINE_2D
+        z_basis = transpose(view.inverse_view)[2].xyz;
+#endif
+#ifdef PIPELINE_3D
+        z_basis = normalize(view.world_position - origin);
+#endif
+    }
+
+    let x_basis = normalize(cross(y_basis, z_basis));
+    y_basis = cross(x_basis, z_basis);
+
+    let scale = core::get_scale(matrix);
+    let scaled_position = local_position * scale;
+    let thickness_data = core::get_thickness_data(
+        shape.thickness,
+        core::f_thickness_type(shape.flags),
+        origin,
+        y_basis,
+    );
+    let aa_padding = core::AA_PADDING / thickness_data.pixels_per_u;
+    let padded_position = scaled_position + sign(local_position) * aa_padding;
+    let uv_ratio = padded_position / scaled_position;
+    let world_position = origin + padded_position.x * x_basis + padded_position.y * y_basis;
+
+    out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
+    out.thickness = core::calculate_thickness(thickness_data, shape.radius, shape.flags);
+
+    out.uv = vertex.xy * uv_ratio;
 
     // Extract cap type from flags
     out.cap = core::f_cap(shape.flags);

--- a/src/render/shaders/shapes/ngon.wgsl
+++ b/src/render/shaders/shapes/ngon.wgsl
@@ -19,7 +19,8 @@ struct Shape {
   
     @location(7) sides: f32,
     @location(8) radius: f32,
-    @location(9) roundness: f32
+    @location(9) roundness: f32,
+    @location(10) padding: vec4<f32>,
 };
 
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
@@ -57,10 +58,6 @@ fn vertex(v: Vertex) -> VertexOutput {
         shape.matrix_3
     );
 
-    // Calculate vertex data shared between most shapes
-    var vertex_data = core::get_vertex_data(matrix, vertex.xy * shape.radius, shape.thickness, shape.flags);
-    out.clip_position = vertex_data.clip_pos;
-
     // Here we precompute several values related to our polygon
 
     // The central angle is the angle at the center of the polygon between two adjacent vertices
@@ -78,10 +75,44 @@ fn vertex(v: Vertex) -> VertexOutput {
     // Calculate our world space apothem for a polygon with the given radius
     var apothem = unit_apothem * shape.radius;
 
-    // We want 1 unit in uv space to be the length of the apothem of our polygon 
-    // so scale world to uv space using the world space apothem
-    out.uv = vertex_data.local_pos / (apothem * vertex_data.scale) * vertex_data.uv_ratio;
-    out.thickness = core::calculate_thickness(vertex_data.thickness_data, apothem, shape.flags);
+    let local_position = vertex.xy * shape.radius;
+
+    let origin = matrix[3].xyz;
+    let alignment = core::f_alignment(shape.flags);
+
+    var y_basis = normalize(matrix[1].xyz);
+    var z_basis = normalize(matrix[2].xyz);
+    if alignment == 1u {
+        y_basis = normalize((view.view * vec4<f32>(0.0, 1.0, 0.0, 0.0)).xyz);
+#ifdef PIPELINE_2D
+        z_basis = transpose(view.inverse_view)[2].xyz;
+#endif
+#ifdef PIPELINE_3D
+        z_basis = normalize(view.world_position - origin);
+#endif
+    }
+
+    let x_basis = normalize(cross(y_basis, z_basis));
+    y_basis = cross(x_basis, z_basis);
+
+    let scale = core::get_scale(matrix);
+    let scaled_position = local_position * scale;
+    let thickness_data = core::get_thickness_data(
+        shape.thickness,
+        core::f_thickness_type(shape.flags),
+        origin,
+        y_basis,
+    );
+    let aa_padding = core::AA_PADDING / thickness_data.pixels_per_u;
+    let padded_position = scaled_position + sign(local_position) * aa_padding;
+    let uv_ratio = padded_position / scaled_position;
+    let world_position = origin + padded_position.x * x_basis + padded_position.y * y_basis;
+
+    out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
+    // We want 1 unit in uv space to be the length of the apothem of our polygon,
+    // so scale world to uv space using the world space apothem.
+    out.uv = scaled_position / (apothem * scale) * uv_ratio;
+    out.thickness = core::calculate_thickness(thickness_data, apothem, shape.flags);
     out.roundness = min(shape.roundness / apothem, 1.0);
 
     // Scale our half side length to match our uv space of 1 unit per apothem

--- a/src/render/shaders/shapes/rect.wgsl
+++ b/src/render/shaders/shapes/rect.wgsl
@@ -1,6 +1,5 @@
 #import bevy_vector_shapes::core
 #import bevy_vector_shapes::core::{view, image, image_sampler}
-#import bevy_vector_shapes::constants::{PI, TAU}
 
 struct Vertex {
     @builtin(instance_index) index: u32,
@@ -19,6 +18,7 @@ struct Shape {
 
     @location(7) size: vec2<f32>,
     @location(8) corner_radii: vec4<f32>,
+    @location(9) padding: vec4<f32>,
 }
 
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
@@ -43,31 +43,56 @@ struct VertexOutput {
 fn vertex(v: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
-    // Vertex positions for a basic quad
     let vertex = v.pos;
     let shape = shapes[v.index];
-
-    // Reconstruct our transformation matrix
     let matrix = mat4x4<f32>(
         shape.matrix_0,
         shape.matrix_1,
         shape.matrix_2,
         shape.matrix_3
     );
-    // Shortest of the two side lengths for the rectangle
-    var shortest_side = min(shape.size.x, shape.size.y);
+    let shortest_side = min(shape.size.x, shape.size.y);
+    let half_shortest_side = shortest_side / 2.0;
 
-    var vertex_data = core::get_vertex_data(matrix, vertex.xy * shape.size / 2.0, shape.thickness, shape.flags);
-    out.clip_position = vertex_data.clip_pos;
-
-    // Our vertex outputs should all be in uv space so scale our uv space such that the shortest side is of length 1
     out.size = shape.size / shortest_side;
-    out.uv = vertex.xy * out.size * vertex_data.uv_ratio;
-    out.thickness = core::calculate_thickness(vertex_data.thickness_data, shortest_side / 2.0, shape.flags);
 
-    // Our corner radii cannot be more than half the shortest side so cap them
+    let local_position = vertex.xy * shape.size / 2.0;
+    let origin = matrix[3].xyz;
+    let alignment = core::f_alignment(shape.flags);
+
+    var y_basis = normalize(matrix[1].xyz);
+    var z_basis = normalize(matrix[2].xyz);
+    if alignment == 1u {
+        y_basis = normalize((view.view * vec4<f32>(0.0, 1.0, 0.0, 0.0)).xyz);
+#ifdef PIPELINE_2D
+        z_basis = transpose(view.inverse_view)[2].xyz;
+#endif
+#ifdef PIPELINE_3D
+        z_basis = normalize(view.world_position - origin);
+#endif
+    }
+
+    let x_basis = normalize(cross(y_basis, z_basis));
+    y_basis = cross(x_basis, z_basis);
+
+    let scale = core::get_scale(matrix);
+    let scaled_position = local_position * scale;
+    let thickness_data = core::get_thickness_data(
+        shape.thickness,
+        core::f_thickness_type(shape.flags),
+        origin,
+        y_basis,
+    );
+    let aa_padding = core::AA_PADDING / thickness_data.pixels_per_u;
+    let padded_position = scaled_position + sign(local_position) * aa_padding;
+    let uv_ratio = padded_position / scaled_position;
+    let world_position = origin + padded_position.x * x_basis + padded_position.y * y_basis;
+
+    out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
+    out.uv = vertex.xy * out.size * uv_ratio;
+    out.thickness = core::calculate_thickness(thickness_data, half_shortest_side, shape.flags);
+
     out.corner_radii = 2.0 * min(shape.corner_radii / shortest_side, vec4<f32>(0.5));
-
     out.color = shape.color;
 #ifdef TEXTURED
     out.texture_uv = core::get_texture_uv(vertex.xy);
@@ -127,13 +152,12 @@ fn fragment(f: FragmentInput) -> @location(0) vec4<f32> {
 
     // Calculate our positions distance from the rectangle
     var dist = rectSDF(f.uv, f.size - radii) - radii;
-    
+
     // Cut off points outside the shape or within the hollow area
     in_shape *= core::step_aa(-f.thickness, dist) * core::step_aa(dist, 0.);
 
-
-
     var color = core::color_output(vec4<f32>(f.color.rgb, in_shape));
+
 #ifdef TEXTURED
     color = color * textureSample(image, image_sampler, f.texture_uv);
 #endif

--- a/src/shapes/disc.rs
+++ b/src/shapes/disc.rs
@@ -82,7 +82,7 @@ impl ShapeComponent for DiscComponent {
             start_angle: self.start_angle,
             end_angle: self.end_angle,
 
-            padding: default(),
+            padding: Vec4::ZERO,
         }
     }
 }
@@ -115,7 +115,7 @@ pub struct DiscData {
     start_angle: f32,
     end_angle: f32,
 
-    padding: [f32; 3],
+    padding: Vec4,
 }
 
 impl DiscData {
@@ -138,7 +138,7 @@ impl DiscData {
             start_angle: 0.0,
             end_angle: 0.0,
 
-            padding: default(),
+            padding: Vec4::ZERO,
         }
     }
 
@@ -162,7 +162,7 @@ impl DiscData {
             start_angle,
             end_angle,
 
-            padding: default(),
+            padding: Vec4::ZERO,
         }
     }
 }

--- a/src/shapes/rectangle.rs
+++ b/src/shapes/rectangle.rs
@@ -52,6 +52,7 @@ impl ShapeComponent for RectangleComponent {
 
             size: self.size.into(),
             corner_radii: self.corner_radii.into(),
+            padding: Vec4::ZERO,
         }
     }
 }
@@ -79,6 +80,7 @@ pub struct RectData {
 
     size: [f32; 2],
     corner_radii: [f32; 4],
+    padding: Vec4,
 }
 
 impl RectData {
@@ -97,6 +99,7 @@ impl RectData {
 
             size: size.into(),
             corner_radii: config.corner_radii.into(),
+            padding: Vec4::ZERO,
         }
     }
 }

--- a/src/shapes/regular_polygon.rs
+++ b/src/shapes/regular_polygon.rs
@@ -65,7 +65,7 @@ impl ShapeComponent for RegularPolygonComponent {
             radius: self.radius,
             roundness: self.roundness,
 
-            padding: default(),
+            padding: Vec4::ZERO,
         }
     }
 }
@@ -100,7 +100,7 @@ pub struct NgonData {
     radius: f32,
     roundness: f32,
 
-    padding: [f32; 3],
+    padding: Vec4,
 }
 
 impl NgonData {
@@ -121,7 +121,7 @@ impl NgonData {
             radius,
             roundness: config.roundness,
 
-            padding: default(),
+            padding: Vec4::ZERO,
         }
     }
 }


### PR DESCRIPTION
Supersedes #71.

## Problem

The gallery could crash on Adreno Vulkan while creating graphics pipelines for several shape shaders. The failures were reproduced on a physical Android device and isolated to the generic shared vertex path used by rect, disc, and regular polygon shaders.

A separate WebGL2 validation issue appeared because rect, disc, and ngon instance data were 112 bytes. WebGL2 uniform batching produced 4032-byte chunks while wgpu expected a 4096-byte binding.

## Fix

- Inline the rect, disc, and ngon vertex math in their shaders instead of routing through the generic shared helper.
- Keep one canonical path for all targets, matching the previous basis, alignment, AA padding, UV, and thickness math.
- Pad rect, disc, and ngon shape data to 128 bytes so WebGL2 uniform batches align cleanly. Line and triangle data were already 128 bytes.

## Verification

- `cargo check --locked --all-features --examples`
- Native deterministic screenshot comparison against `main`:
  - 2D gallery: AE=0
  - 3D gallery: AE=0
- Physical Android device, Adreno Vulkan backend:
  - 2D gallery: no crash
  - 3D gallery: no crash
- Browser/WASM via Bevy CLI + Playwright:
  - 2D WebGPU: pass
  - 2D WebGL2: pass after the padding fix
  - 3D WebGL2: pass

Note: 3D WebGPU still hits an unrelated Bevy PBR/WebGPU storage-buffer panic before this crate's shape shaders are the failing path.
