### PR TITLE
Harden Adreno Vulkan shape vertex shaders

### DIFF
--- a/src/render/shaders/shapes/disc.wgsl
+++ b/src/render/shaders/shapes/disc.wgsl
@@ -89,6 +89,7 @@ fn vertex(v: Vertex) -> VertexOutput {
     let uv_ratio = padded_position / scaled_position;
     let world_position = origin + padded_position.x * x_basis + padded_position.y * y_basis;
 
+    // Multiply the world space position by the view projection matrix to convert to our clip position
     out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
     out.uv = vertex.xy * uv_ratio;
     out.thickness = core::calculate_thickness(thickness_data, shape.radius, shape.flags);

--- a/src/render/shaders/shapes/disc.wgsl
+++ b/src/render/shaders/shapes/disc.wgsl
@@ -57,12 +57,41 @@ fn vertex(v: Vertex) -> VertexOutput {
         shape.matrix_3
     );
 
-    var vertex_data = core::get_vertex_data(matrix, vertex.xy * shape.radius, shape.thickness, shape.flags);
+    let local_position = vertex.xy * shape.radius;
+    let origin = matrix[3].xyz;
+    let alignment = core::f_alignment(shape.flags);
 
-    // Multiply the world space position by the view projection matrix to convert to our clip position
-    out.clip_position = vertex_data.clip_pos;
-    out.uv = vertex.xy * vertex_data.uv_ratio;
-    out.thickness = core::calculate_thickness(vertex_data.thickness_data, shape.radius, shape.flags);
+    var y_basis = normalize(matrix[1].xyz);
+    var z_basis = normalize(matrix[2].xyz);
+    if alignment == 1u {
+        y_basis = normalize((view.view * vec4<f32>(0.0, 1.0, 0.0, 0.0)).xyz);
+#ifdef PIPELINE_2D
+        z_basis = transpose(view.inverse_view)[2].xyz;
+#endif
+#ifdef PIPELINE_3D
+        z_basis = normalize(view.world_position - origin);
+#endif
+    }
+
+    let x_basis = normalize(cross(y_basis, z_basis));
+    y_basis = cross(x_basis, z_basis);
+
+    let scale = core::get_scale(matrix);
+    let scaled_position = local_position * scale;
+    let thickness_data = core::get_thickness_data(
+        shape.thickness,
+        core::f_thickness_type(shape.flags),
+        origin,
+        y_basis,
+    );
+    let aa_padding = core::AA_PADDING / thickness_data.pixels_per_u;
+    let padded_position = scaled_position + sign(local_position) * aa_padding;
+    let uv_ratio = padded_position / scaled_position;
+    let world_position = origin + padded_position.x * x_basis + padded_position.y * y_basis;
+
+    out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
+    out.uv = vertex.xy * uv_ratio;
+    out.thickness = core::calculate_thickness(thickness_data, shape.radius, shape.flags);
 
     // Extract cap type from flags
     out.cap = core::f_cap(shape.flags);

--- a/src/render/shaders/shapes/ngon.wgsl
+++ b/src/render/shaders/shapes/ngon.wgsl
@@ -58,10 +58,6 @@ fn vertex(v: Vertex) -> VertexOutput {
         shape.matrix_3
     );
 
-    // Calculate vertex data shared between most shapes
-    var vertex_data = core::get_vertex_data(matrix, vertex.xy * shape.radius, shape.thickness, shape.flags);
-    out.clip_position = vertex_data.clip_pos;
-
     // Here we precompute several values related to our polygon
 
     // The central angle is the angle at the center of the polygon between two adjacent vertices
@@ -79,10 +75,44 @@ fn vertex(v: Vertex) -> VertexOutput {
     // Calculate our world space apothem for a polygon with the given radius
     var apothem = unit_apothem * shape.radius;
 
-    // We want 1 unit in uv space to be the length of the apothem of our polygon 
-    // so scale world to uv space using the world space apothem
-    out.uv = vertex_data.local_pos / (apothem * vertex_data.scale) * vertex_data.uv_ratio;
-    out.thickness = core::calculate_thickness(vertex_data.thickness_data, apothem, shape.flags);
+    let local_position = vertex.xy * shape.radius;
+
+    let origin = matrix[3].xyz;
+    let alignment = core::f_alignment(shape.flags);
+
+    var y_basis = normalize(matrix[1].xyz);
+    var z_basis = normalize(matrix[2].xyz);
+    if alignment == 1u {
+        y_basis = normalize((view.view * vec4<f32>(0.0, 1.0, 0.0, 0.0)).xyz);
+#ifdef PIPELINE_2D
+        z_basis = transpose(view.inverse_view)[2].xyz;
+#endif
+#ifdef PIPELINE_3D
+        z_basis = normalize(view.world_position - origin);
+#endif
+    }
+
+    let x_basis = normalize(cross(y_basis, z_basis));
+    y_basis = cross(x_basis, z_basis);
+
+    let scale = core::get_scale(matrix);
+    let scaled_position = local_position * scale;
+    let thickness_data = core::get_thickness_data(
+        shape.thickness,
+        core::f_thickness_type(shape.flags),
+        origin,
+        y_basis,
+    );
+    let aa_padding = core::AA_PADDING / thickness_data.pixels_per_u;
+    let padded_position = scaled_position + sign(local_position) * aa_padding;
+    let uv_ratio = padded_position / scaled_position;
+    let world_position = origin + padded_position.x * x_basis + padded_position.y * y_basis;
+
+    out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
+    // We want 1 unit in uv space to be the length of the apothem of our polygon,
+    // so scale world to uv space using the world space apothem.
+    out.uv = scaled_position / (apothem * scale) * uv_ratio;
+    out.thickness = core::calculate_thickness(thickness_data, apothem, shape.flags);
     out.roundness = min(shape.roundness / apothem, 1.0);
 
     // Scale our half side length to match our uv space of 1 unit per apothem

--- a/src/render/shaders/shapes/ngon.wgsl
+++ b/src/render/shaders/shapes/ngon.wgsl
@@ -76,7 +76,6 @@ fn vertex(v: Vertex) -> VertexOutput {
     var apothem = unit_apothem * shape.radius;
 
     let local_position = vertex.xy * shape.radius;
-
     let origin = matrix[3].xyz;
     let alignment = core::f_alignment(shape.flags);
 
@@ -109,8 +108,8 @@ fn vertex(v: Vertex) -> VertexOutput {
     let world_position = origin + padded_position.x * x_basis + padded_position.y * y_basis;
 
     out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
-    // We want 1 unit in uv space to be the length of the apothem of our polygon,
-    // so scale world to uv space using the world space apothem.
+    // We want 1 unit in uv space to be the length of the apothem of our polygon
+    // so scale world to uv space using the world space apothem
     out.uv = scaled_position / (apothem * scale) * uv_ratio;
     out.thickness = core::calculate_thickness(thickness_data, apothem, shape.flags);
     out.roundness = min(shape.roundness / apothem, 1.0);

--- a/src/render/shaders/shapes/rect.wgsl
+++ b/src/render/shaders/shapes/rect.wgsl
@@ -44,29 +44,55 @@ struct VertexOutput {
 fn vertex(v: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
-    // Vertex positions for a basic quad
     let vertex = v.pos;
     let shape = shapes[v.index];
-
-    // Reconstruct our transformation matrix
     let matrix = mat4x4<f32>(
         shape.matrix_0,
         shape.matrix_1,
         shape.matrix_2,
         shape.matrix_3
     );
-    // Shortest of the two side lengths for the rectangle
-    var shortest_side = min(shape.size.x, shape.size.y);
+    let shortest_side = min(shape.size.x, shape.size.y);
+    let half_shortest_side = shortest_side / 2.0;
 
-    var vertex_data = core::get_vertex_data(matrix, vertex.xy * shape.size / 2.0, shape.thickness, shape.flags);
-    out.clip_position = vertex_data.clip_pos;
-
-    // Our vertex outputs should all be in uv space so scale our uv space such that the shortest side is of length 1
     out.size = shape.size / shortest_side;
-    out.uv = vertex.xy * out.size * vertex_data.uv_ratio;
-    out.thickness = core::calculate_thickness(vertex_data.thickness_data, shortest_side / 2.0, shape.flags);
 
-    // Our corner radii cannot be more than half the shortest side so cap them
+    let local_position = vertex.xy * shape.size / 2.0;
+    let origin = matrix[3].xyz;
+    let alignment = core::f_alignment(shape.flags);
+
+    var y_basis = normalize(matrix[1].xyz);
+    var z_basis = normalize(matrix[2].xyz);
+    if alignment == 1u {
+        y_basis = normalize((view.view * vec4<f32>(0.0, 1.0, 0.0, 0.0)).xyz);
+#ifdef PIPELINE_2D
+        z_basis = transpose(view.inverse_view)[2].xyz;
+#endif
+#ifdef PIPELINE_3D
+        z_basis = normalize(view.world_position - origin);
+#endif
+    }
+
+    let x_basis = normalize(cross(y_basis, z_basis));
+    y_basis = cross(x_basis, z_basis);
+
+    let scale = core::get_scale(matrix);
+    let scaled_position = local_position * scale;
+    let thickness_data = core::get_thickness_data(
+        shape.thickness,
+        core::f_thickness_type(shape.flags),
+        origin,
+        y_basis,
+    );
+    let aa_padding = core::AA_PADDING / thickness_data.pixels_per_u;
+    let padded_position = scaled_position + sign(local_position) * aa_padding;
+    let uv_ratio = padded_position / scaled_position;
+    let world_position = origin + padded_position.x * x_basis + padded_position.y * y_basis;
+
+    out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
+    out.uv = vertex.xy * out.size * uv_ratio;
+    out.thickness = core::calculate_thickness(thickness_data, half_shortest_side, shape.flags);
+
     out.corner_radii = 2.0 * min(shape.corner_radii / shortest_side, vec4<f32>(0.5));
 
     out.color = shape.color;

--- a/src/render/shaders/shapes/rect.wgsl
+++ b/src/render/shaders/shapes/rect.wgsl
@@ -44,17 +44,21 @@ struct VertexOutput {
 fn vertex(v: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
+    // Vertex positions for a basic quad
     let vertex = v.pos;
     let shape = shapes[v.index];
+
+    // Reconstruct our transformation matrix
     let matrix = mat4x4<f32>(
         shape.matrix_0,
         shape.matrix_1,
         shape.matrix_2,
         shape.matrix_3
     );
-    let shortest_side = min(shape.size.x, shape.size.y);
-    let half_shortest_side = shortest_side / 2.0;
+    // Shortest of the two side lengths for the rectangle
+    var shortest_side = min(shape.size.x, shape.size.y);
 
+    // Our vertex outputs should all be in uv space so scale our uv space such that the shortest side is of length 1
     out.size = shape.size / shortest_side;
 
     let local_position = vertex.xy * shape.size / 2.0;
@@ -91,8 +95,9 @@ fn vertex(v: Vertex) -> VertexOutput {
 
     out.clip_position = view.view_proj * vec4<f32>(world_position, 1.0);
     out.uv = vertex.xy * out.size * uv_ratio;
-    out.thickness = core::calculate_thickness(thickness_data, half_shortest_side, shape.flags);
+    out.thickness = core::calculate_thickness(thickness_data, shortest_side / 2.0, shape.flags);
 
+    // Our corner radii cannot be more than half the shortest side so cap them
     out.corner_radii = 2.0 * min(shape.corner_radii / shortest_side, vec4<f32>(0.5));
 
     out.color = shape.color;


### PR DESCRIPTION
Follow-up to #72 with the smaller Android/Adreno shader fix I isolated while testing.

This keeps the existing data layout changes and avoids `core::get_vertex_data(...)` only in the affected `rect`, `disc`, and `ngon` vertex shaders. I left the line shader and fragment shader changes out because they were not needed for the Adreno fix in my tests.

Smaller variants I tried that still failed on the Adreno device:
- only changing `get_vertex_data` to use `matrix[3].xyz` for the origin
- keeping `get_vertex_data`, but moving the basis-vector math inline inside that helper
- keeping the per-shape path, but calling `core::get_basis_vectors(...)` from `rect`, `disc`, and `ngon` instead of inlining the basis math there

`core::calculate_thickness(...)` is still used in this PR. The part I could not safely share on Adreno was the vertex-data setup before that: origin, basis vectors, scale, AA padding, UV ratio, and world position.

Validation I ran:
- `cargo check --all-features`
- Real Adreno 725 Vulkan harness reaches the stable rendered scene
- Static visual cases for rounded rects, arcs, ngons, and line caps/thickness matched pixel-for-pixel against #72 on the Adreno device